### PR TITLE
Fix constraint error for 'center' and 'centerFill'

### DIFF
--- a/ParallaxHeader/ParallaxHeader.swift
+++ b/ParallaxHeader/ParallaxHeader.swift
@@ -323,7 +323,7 @@ public class ParallaxHeader: NSObject {
                 toItem: contentView,
                 attribute: NSLayoutAttribute.centerX,
                 multiplier: 1,
-                constant: height
+                constant: 0
             )
         )
     }
@@ -372,7 +372,7 @@ public class ParallaxHeader: NSObject {
                 toItem: contentView,
                 attribute: NSLayoutAttribute.centerX,
                 multiplier: 1,
-                constant: height
+                constant: 0
             )
         )
     }


### PR DESCRIPTION
Hi 👋 

Thanks for your awesome library! 👍
I just notice a small constraint error. If you:
1. Launch your example project
2. Test one tableView with parallaxHeader using `centerFill` as `mode`
3. You'll see an error in the logs "Unable to satisfy constraint... attempt recovering by breaking constraint centerX"

I fixed it! Works like a charm ✨
