### PR TITLE
Revert "fix safeAreaInsets for iOS 11"

### DIFF
--- a/ParallaxHeader/ParallaxHeader.swift
+++ b/ParallaxHeader/ParallaxHeader.swift
@@ -436,10 +436,7 @@ public class ParallaxHeader: NSObject {
             return
         }
         let minimumHeight = min(self.minimumHeight, self.height)
-        var relativeYOffset = scrollView.contentOffset.y + scrollView.contentInset.top - height
-        if #available(iOS 11.0, *) {
-            relativeYOffset += scrollView.safeAreaInsets.top
-        }
+        let relativeYOffset = scrollView.contentOffset.y + scrollView.contentInset.top - height
         let relativeHeight = -relativeYOffset
         
         let frame = CGRect(


### PR DESCRIPTION
This reverts commit 77814dc61a2715a76f6f537d6de44e613d927060.

We're using the parallax header on the very top of one of our screens. This change leads to a top offset (44pt) on newer "notch devices" as we don't want to constraint to the safeArea but, to the very top of the screen.