### PR TITLE
Ignore top safe area insets if needed &  SPM support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+# MacOS
+## Credits ->  https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
 ## Build generated
 build/
 DerivedData/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ParallaxHeader",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(
+            name: "ParallaxHeader",
+            targets: ["ParallaxHeader"]
+        ),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "ParallaxHeader",
+            dependencies: [
+            ],
+            path: "ParallaxHeader",
+            exclude: [
+                "Info.plist"
+                ]
+        ),
+        .testTarget(
+            name: "ParallaxHeaderTests",
+            dependencies: ["ParallaxHeader"],
+            path: "ParallaxHeaderTests",
+            exclude: ["Info.plist"]
+        ),
+    ]
+)

--- a/ParallaxHeader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ParallaxHeader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ParallaxHeader.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ParallaxHeader.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ParallaxHeader/ParallaxHeader.swift
+++ b/ParallaxHeader/ParallaxHeader.swift
@@ -63,6 +63,10 @@ public class ParallaxHeader: NSObject {
      */
     public var parallaxHeaderDidScrollHandler: ParallaxHeaderHandlerBlock?
     
+    /// This is to support a usecase where a parallax header is being used at the very top edge of the screen.
+    /// If this is set to true then the header will be pinned at the top of the scrollView. Default value is `false`
+    public var ignoreToSafeAreaInset:Bool = false
+    
     private weak var _scrollView: UIScrollView?
     var scrollView: UIScrollView! {
         get {
@@ -438,7 +442,9 @@ public class ParallaxHeader: NSObject {
         let minimumHeight = min(self.minimumHeight, self.height)
         var relativeYOffset = scrollView.contentOffset.y + scrollView.contentInset.top - height
         if #available(iOS 11.0, *) {
-            relativeYOffset += scrollView.safeAreaInsets.top
+            if !ignoreToSafeAreaInset {
+                relativeYOffset += scrollView.safeAreaInsets.top
+            }
         }
         let relativeHeight = -relativeYOffset
         

--- a/ParallaxHeader/ParallaxHeader.swift
+++ b/ParallaxHeader/ParallaxHeader.swift
@@ -65,7 +65,7 @@ public class ParallaxHeader: NSObject {
     
     /// This is to support a usecase where a parallax header is being used at the very top edge of the screen.
     /// If this is set to true then the header will be pinned at the top of the scrollView. Default value is `false`
-    public var ignoreToSafeAreaInset:Bool = false
+    public var ignoreTopSafeAreaInset:Bool = false
     
     private weak var _scrollView: UIScrollView?
     var scrollView: UIScrollView! {
@@ -442,7 +442,7 @@ public class ParallaxHeader: NSObject {
         let minimumHeight = min(self.minimumHeight, self.height)
         var relativeYOffset = scrollView.contentOffset.y + scrollView.contentInset.top - height
         if #available(iOS 11.0, *) {
-            if !ignoreToSafeAreaInset {
+            if !ignoreTopSafeAreaInset {
                 relativeYOffset += scrollView.safeAreaInsets.top
             }
         }


### PR DESCRIPTION

# Ignore Safe Areas
Issue: Safe area is been used to pin contentView without taking into consideration some of other custom layouts, for example having an imageView as header covering the whole navBar including safeAreas. 

This PR adds an optional flag were users can set it to true if their headers  fill the whole safe area. 

```swift
 /// This is to support a usecase where a parallax header is being used at the very top edge of the screen.
/// If this is set to true then the header will be pinned at the top of the scrollView. Default value is `false`
    public var ignoreTopSafeAreaInset:Bool = false
```

Usage: 
`myScrollview.parallaxHeader.ignoreTopSafeAreaInset = true`

# Swift Package Manager (SPM)
This PR also includes SPM support without any changes to source code structure. Only a package manifest file is added which points to the right source files. 

Note: The reason to include SPM support on a single PR is because I am using this branch in my project. 


